### PR TITLE
Implement offline local cursor application

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,329 +1,466 @@
-import os
-import json
 import asyncio
+import json
+import os
 from datetime import datetime
-from typing import List, Optional, Dict, Any
+from typing import Any, AsyncGenerator, Dict, List, Optional
 
 import httpx
-from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from sse_starlette.sse import EventSourceResponse
 
-APP_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-BACKEND_DIR = os.path.dirname(os.path.abspath(__file__))
-FRONTEND_DIR = os.path.join(APP_DIR, "frontend")
-DATA_DIR = os.path.join(BACKEND_DIR, "data")
-SETTINGS_PATH = os.path.join(BACKEND_DIR, "settings.json")
-HISTORY_PATH = os.path.join(DATA_DIR, "history.json")
+APP_ROOT = os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir)))
+BACKEND_ROOT = os.path.dirname(os.path.abspath(__file__))
+FRONTEND_ROOT = os.path.join(APP_ROOT, "frontend")
+WORKSPACE_ROOT = os.path.join(APP_ROOT, "workspace")
+SETTINGS_PATH = os.path.join(BACKEND_ROOT, "settings.json")
+HISTORY_DIR = os.path.join(BACKEND_ROOT, "data")
+HISTORY_PATH = os.path.join(HISTORY_DIR, "history.json")
 
-DEFAULT_SETTINGS = {
+DEFAULT_SETTINGS: Dict[str, Any] = {
     "backend": "ollama",
     "ollama_base_url": "http://127.0.0.1:11434",
     "lmstudio_base_url": "http://127.0.0.1:1234",
-    "model": "qwen2.5-coder:7b",
+    "model": "",
     "temperature": 0.2,
     "top_p": 0.9,
-    "max_tokens": 2048
+    "max_tokens": 2048,
 }
 
-os.makedirs(DATA_DIR, exist_ok=True)
-if not os.path.exists(SETTINGS_PATH):
-    with open(SETTINGS_PATH, "w", encoding="utf-8") as f:
-        json.dump(DEFAULT_SETTINGS, f, indent=2)
-if not os.path.exists(HISTORY_PATH):
-    with open(HISTORY_PATH, "w", encoding="utf-8") as f:
-        json.dump({"sessions": []}, f, indent=2)
+os.makedirs(WORKSPACE_ROOT, exist_ok=True)
+os.makedirs(HISTORY_DIR, exist_ok=True)
 
-app = FastAPI()
+
+def _ensure_settings() -> None:
+    if not os.path.exists(SETTINGS_PATH):
+        with open(SETTINGS_PATH, "w", encoding="utf-8") as fh:
+            json.dump(DEFAULT_SETTINGS, fh, indent=2)
+
+    if not os.path.exists(HISTORY_PATH):
+        with open(HISTORY_PATH, "w", encoding="utf-8") as fh:
+            json.dump({"sessions": []}, fh, indent=2)
+
+
+_ensure_settings()
+
+
+def load_settings() -> Dict[str, Any]:
+    with open(SETTINGS_PATH, "r", encoding="utf-8") as fh:
+        settings = json.load(fh)
+    merged = DEFAULT_SETTINGS.copy()
+    merged.update(settings)
+    return merged
+
+
+def save_settings(settings: Dict[str, Any]) -> None:
+    merged = DEFAULT_SETTINGS.copy()
+    merged.update(settings)
+    with open(SETTINGS_PATH, "w", encoding="utf-8") as fh:
+        json.dump(merged, fh, indent=2)
+
+
+def append_history(entry: Dict[str, Any]) -> None:
+    try:
+        with open(HISTORY_PATH, "r", encoding="utf-8") as fh:
+            history = json.load(fh)
+        history.setdefault("sessions", []).append(entry)
+        with open(HISTORY_PATH, "w", encoding="utf-8") as fh:
+            json.dump(history, fh, indent=2)
+    except Exception:
+        # history failures should never break chat
+        pass
+
+
+app = FastAPI(title="Local Cursor")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    allow_credentials=True,
 )
 
-# Serve static frontend
-app.mount("/assets", StaticFiles(directory=os.path.join(FRONTEND_DIR, "assets")), name="assets")
+app.mount("/assets", StaticFiles(directory=os.path.join(FRONTEND_ROOT, "assets")), name="assets")
+
 
 @app.get("/")
-async def root():
-    return FileResponse(os.path.join(FRONTEND_DIR, "index.html"))
+async def index() -> FileResponse:
+    return FileResponse(os.path.join(FRONTEND_ROOT, "index.html"))
 
-def load_settings() -> Dict[str, Any]:
-    with open(SETTINGS_PATH, "r", encoding="utf-8") as f:
-        return json.load(f)
 
-def save_settings(s: Dict[str, Any]) -> None:
-    with open(SETTINGS_PATH, "w", encoding="utf-8") as f:
-        json.dump(s, f, indent=2)
+@app.get("/health")
+async def health() -> Dict[str, Any]:
+    settings = load_settings()
+    return {"status": "ok", "settings": settings}
 
-def append_history(entry: Dict[str, Any]) -> None:
-    with open(HISTORY_PATH, "r", encoding="utf-8") as f:
-        hist = json.load(f)
-    hist.setdefault("sessions", []).append(entry)
-    with open(HISTORY_PATH, "w", encoding="utf-8") as f:
-        json.dump(hist, f, indent=2)
 
-@app.get("/api/health")
-async def health():
-    s = load_settings()
-    return {"status": "ok", "settings": s}
-
-@app.get("/api/settings")
-async def get_settings():
+@app.get("/settings")
+async def get_settings() -> Dict[str, Any]:
     return load_settings()
 
-@app.post("/api/settings")
-async def update_settings(payload: Dict[str, Any]):
-    s = load_settings()
-    s.update({
-        "backend": payload.get("backend", s["backend"]),
-        "ollama_base_url": payload.get("ollama_base_url", s["ollama_base_url"]),
-        "lmstudio_base_url": payload.get("lmstudio_base_url", s["lmstudio_base_url"]),
-        "model": payload.get("model", s["model"]),
-        "temperature": payload.get("temperature", s["temperature"]),
-        "top_p": payload.get("top_p", s["top_p"]),
-        "max_tokens": payload.get("max_tokens", s["max_tokens"]),
+
+@app.post("/settings")
+async def update_settings(payload: Dict[str, Any]) -> Dict[str, Any]:
+    settings = load_settings()
+    settings.update({
+        "backend": payload.get("backend", settings["backend"]),
+        "ollama_base_url": payload.get("ollama_base_url", settings["ollama_base_url"]),
+        "lmstudio_base_url": payload.get("lmstudio_base_url", settings["lmstudio_base_url"]),
+        "model": payload.get("model", settings["model"]),
+        "temperature": payload.get("temperature", settings["temperature"]),
+        "top_p": payload.get("top_p", settings["top_p"]),
+        "max_tokens": payload.get("max_tokens", settings["max_tokens"]),
     })
-    save_settings(s)
-    return {"ok": True, "settings": s}
+    save_settings(settings)
+    return {"ok": True, "settings": settings}
 
-@app.get("/api/models")
-async def list_models():
-    s = load_settings()
-    backend = s["backend"]
-    timeout = httpx.Timeout(5.0, read=15.0)
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        try:
-            if backend == "ollama":
-                r = await client.get(f'{s["ollama_base_url"].rstrip("/")}/api/tags')
-                r.raise_for_status()
-                data = r.json()
-                models = [m.get("name") for m in data.get("models", []) if m.get("name")]
-                return {"backend": "ollama", "models": models}
+
+@app.get("/models")
+async def list_models(backend: Optional[str] = None, base_url: Optional[str] = None) -> Dict[str, Any]:
+    settings = load_settings()
+    backend_name = backend or settings["backend"]
+    timeout = httpx.Timeout(5.0, read=20.0)
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if backend_name == "ollama":
+                url = base_url or settings["ollama_base_url"]
+                response = await client.get(f"{url.rstrip('/')}/api/tags")
+                response.raise_for_status()
+                data = response.json()
+                models = [item["name"] for item in data.get("models", []) if item.get("name")]
             else:
-                # LM Studio OpenAI-compatible
-                r = await client.get(f'{s["lmstudio_base_url"].rstrip("/")}/v1/models')
-                r.raise_for_status()
-                data = r.json()
-                models = [m.get("id") for m in data.get("data", []) if m.get("id")]
-                return {"backend": "lmstudio", "models": models}
-        except Exception as e:
-            return {"backend": backend, "models": [], "error": str(e)}
+                url = base_url or settings["lmstudio_base_url"]
+                response = await client.get(f"{url.rstrip('/')}/v1/models")
+                response.raise_for_status()
+                data = response.json()
+                models = [item["id"] for item in data.get("data", []) if item.get("id")]
+    except Exception as exc:
+        return {"backend": backend_name, "models": [], "error": str(exc)}
 
-@app.post("/api/chat/stream")
-async def chat_stream(request: Request):
+    return {"backend": backend_name, "models": models}
+
+
+def _flatten_messages(messages: List[Dict[str, Any]]) -> str:
+    parts: List[str] = []
+    for message in messages:
+        role = message.get("role", "user").upper()
+        content = message.get("content", "")
+        parts.append(f"{role}: {content}")
+    parts.append("ASSISTANT:")
+    return "\n".join(parts)
+
+
+async def _stream_ollama(
+    client: httpx.AsyncClient,
+    url: str,
+    payload: Dict[str, Any],
+    request: Request,
+) -> AsyncGenerator[Dict[str, str], None]:
+    async with client.stream("POST", f"{url.rstrip('/')}/api/generate", json=payload) as response:
+        response.raise_for_status()
+        async for line in response.aiter_lines():
+            if await request.is_disconnected():
+                break
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            token = data.get("response")
+            if token:
+                yield {"event": "delta", "data": token}
+            if data.get("done"):
+                break
+
+
+async def _stream_lmstudio(
+    client: httpx.AsyncClient,
+    url: str,
+    payload: Dict[str, Any],
+    request: Request,
+) -> AsyncGenerator[Dict[str, str], None]:
+    async with client.stream("POST", f"{url.rstrip('/')}/v1/chat/completions", json=payload) as response:
+        response.raise_for_status()
+        async for raw_line in response.aiter_lines():
+            if await request.is_disconnected():
+                break
+            if not raw_line:
+                continue
+            if not raw_line.startswith("data:"):
+                continue
+            chunk = raw_line[len("data:") :].strip()
+            if chunk == "[DONE]":
+                break
+            try:
+                data = json.loads(chunk)
+            except json.JSONDecodeError:
+                continue
+            delta = data.get("choices", [{}])[0].get("delta", {}).get("content")
+            if delta:
+                yield {"event": "delta", "data": delta}
+
+
+@app.post("/chat_stream")
+async def chat_stream(request: Request) -> EventSourceResponse:
     payload = await request.json()
-    user_messages = payload.get("messages", [])
-    s = load_settings()
+    settings = load_settings()
+    backend_name = payload.get("backend") or settings["backend"]
+    model = payload.get("model") or settings["model"]
+    temperature = payload.get("temperature", settings["temperature"])
+    top_p = payload.get("top_p", settings["top_p"])
+    max_tokens = payload.get("max_tokens", settings["max_tokens"])
+    messages = payload.get("messages", [])
 
-    async def event_generator():
-        # stream from local backend
-        backend = s["backend"]
-        model = payload.get("model") or s["model"]
-        temperature = payload.get("temperature", s["temperature"])
-        top_p = payload.get("top_p", s["top_p"])
-        max_tokens = payload.get("max_tokens", s["max_tokens"])
+    if not model:
+        raise HTTPException(400, "Model is required")
 
+    async def event_generator() -> AsyncGenerator[Dict[str, str], None]:
         timeout = httpx.Timeout(5.0, read=300.0)
         async with httpx.AsyncClient(timeout=timeout) as client:
-            if backend == "ollama":
-                # Convert chat format to a single prompt for simplicity
-                # (You can improve here to use /api/chat for multi-turn with roles)
-                prompt_parts = []
-                for m in user_messages:
-                    role = m.get("role", "user")
-                    content = m.get("content", "")
-                    prompt_parts.append(f"{role.upper()}: {content}")
-                prompt = "\n".join(prompt_parts) + "\nASSISTANT:"
-
+            if backend_name == "ollama":
+                base_url = payload.get("ollama_base_url") or settings["ollama_base_url"]
                 req = {
                     "model": model,
-                    "prompt": prompt,
+                    "prompt": _flatten_messages(messages),
                     "stream": True,
                     "options": {
                         "temperature": temperature,
                         "top_p": top_p,
-                        "num_ctx": max_tokens
-                    }
+                        "num_ctx": max_tokens,
+                    },
                 }
                 try:
-                    async with client.stream("POST", f'{s["ollama_base_url"].rstrip("/")}/api/generate', json=req) as r:
-                        async for line in r.aiter_lines():
-                            if await request.is_disconnected():
-                                break
-                            if not line:
-                                continue
-                            try:
-                                data = json.loads(line)
-                            except Exception:
-                                continue
-                            token = data.get("response", "")
-                            if token:
-                                yield {"event": "delta", "data": token}
-                            if data.get("done"):
-                                break
-                except Exception as e:
-                    yield {"event": "error", "data": str(e)}
+                    async for event in _stream_ollama(client, base_url, req, request):
+                        yield event
+                except Exception as exc:
+                    yield {"event": "error", "data": str(exc)}
             else:
-                # LM Studio (OpenAI-compatible) streaming chat completions
-                messages = [{"role": m.get("role", "user"), "content": m.get("content","")} for m in user_messages]
+                base_url = payload.get("lmstudio_base_url") or settings["lmstudio_base_url"]
                 req = {
                     "model": model,
                     "messages": messages,
                     "stream": True,
                     "temperature": temperature,
                     "top_p": top_p,
-                    "max_tokens": max_tokens
+                    "max_tokens": max_tokens,
                 }
                 try:
-                    async with client.stream("POST", f'{s["lmstudio_base_url"].rstrip("/")}/v1/chat/completions', json=req) as r:
-                        async for line in r.aiter_lines():
-                            if await request.is_disconnected():
-                                break
-                            if not line.startswith("data:"):
-                                continue
-                            chunk = line[len("data:"):].strip()
-                            if chunk == "[DONE]":
-                                break
-                            try:
-                                data = json.loads(chunk)
-                                delta = data.get("choices",[{}])[0].get("delta",{}).get("content","")
-                                if delta:
-                                    yield {"event": "delta", "data": delta}
-                            except Exception:
-                                continue
-                except Exception as e:
-                    yield {"event": "error", "data": str(e)}
+                    async for event in _stream_lmstudio(client, base_url, req, request):
+                        yield event
+                except Exception as exc:
+                    yield {"event": "error", "data": str(exc)}
+        yield {"event": "end", "data": ""}
 
-        # Record history minimal
-        try:
-            append_history({
-                "ts": datetime.utcnow().isoformat()+"Z",
-                "messages": user_messages,
+    asyncio.create_task(
+        asyncio.to_thread(
+            append_history,
+            {
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+                "backend": backend_name,
                 "model": model,
-                "backend": backend
-            })
-        except Exception:
-            pass
+                "messages": messages,
+            },
+        )
+    )
 
     return EventSourceResponse(event_generator())
 
-# -------- File System APIs --------
 
-def safe_join(base: str, path: str) -> str:
-    full = os.path.abspath(os.path.join(base, path))
-    if not full.startswith(os.path.abspath(base)):
-        raise HTTPException(400, "Invalid path traversal")
-    return full
+@app.post("/chat_once")
+async def chat_once(payload: Dict[str, Any]) -> Dict[str, Any]:
+    settings = load_settings()
+    backend_name = payload.get("backend") or settings["backend"]
+    model = payload.get("model") or settings["model"]
+    temperature = payload.get("temperature", settings["temperature"])
+    top_p = payload.get("top_p", settings["top_p"])
+    max_tokens = payload.get("max_tokens", settings["max_tokens"])
+    messages = payload.get("messages", [])
 
-WORKSPACE_ROOT = os.path.abspath(os.path.join(APP_DIR, "workspace"))
-os.makedirs(WORKSPACE_ROOT, exist_ok=True)
+    if not model:
+        raise HTTPException(400, "Model is required")
 
-@app.get("/api/fs/list")
-async def fs_list(path: str = ""):
-    target = safe_join(WORKSPACE_ROOT, path)
+    timeout = httpx.Timeout(10.0, read=300.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        if backend_name == "ollama":
+            base_url = payload.get("ollama_base_url") or settings["ollama_base_url"]
+            req = {
+                "model": model,
+                "prompt": _flatten_messages(messages),
+                "stream": False,
+                "options": {
+                    "temperature": temperature,
+                    "top_p": top_p,
+                    "num_ctx": max_tokens,
+                },
+            }
+            response = await client.post(f"{base_url.rstrip('/')}/api/generate", json=req)
+            response.raise_for_status()
+            data = response.json()
+            text = data.get("response", "")
+        else:
+            base_url = payload.get("lmstudio_base_url") or settings["lmstudio_base_url"]
+            req = {
+                "model": model,
+                "messages": messages,
+                "stream": False,
+                "temperature": temperature,
+                "top_p": top_p,
+                "max_tokens": max_tokens,
+            }
+            response = await client.post(f"{base_url.rstrip('/')}/v1/chat/completions", json=req)
+            response.raise_for_status()
+            data = response.json()
+            text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+
+    append_history(
+        {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "backend": backend_name,
+            "model": model,
+            "messages": messages,
+            "response": text,
+        }
+    )
+
+    return {"backend": backend_name, "model": model, "response": text}
+
+
+# -----------------------
+# Workspace file endpoints
+# -----------------------
+
+def _safe_join(base: str, path: str) -> str:
+    target = os.path.abspath(os.path.join(base, path))
+    base_abs = os.path.abspath(base)
+    if not target.startswith(base_abs):
+        raise HTTPException(status_code=400, detail="Invalid path")
+    return target
+
+
+@app.get("/fs/list")
+async def fs_list(path: str = "") -> Dict[str, Any]:
+    target = _safe_join(WORKSPACE_ROOT, path)
     if not os.path.exists(target):
         return {"path": path, "items": []}
-    items = []
+    items: List[Dict[str, Any]] = []
     for name in sorted(os.listdir(target)):
-        p = os.path.join(target, name)
-        items.append({
-            "name": name,
-            "path": os.path.relpath(p, WORKSPACE_ROOT).replace("\\","/"),
-            "is_dir": os.path.isdir(p),
-            "size": os.path.getsize(p) if os.path.isfile(p) else 0
-        })
+        full_path = os.path.join(target, name)
+        items.append(
+            {
+                "name": name,
+                "path": os.path.relpath(full_path, WORKSPACE_ROOT).replace("\\", "/"),
+                "is_dir": os.path.isdir(full_path),
+                "size": os.path.getsize(full_path) if os.path.isfile(full_path) else 0,
+            }
+        )
     return {"path": path, "items": items}
 
-@app.get("/api/fs/read")
-async def fs_read(path: str):
-    target = safe_join(WORKSPACE_ROOT, path)
+
+@app.get("/fs/read")
+async def fs_read(path: str) -> Dict[str, Any]:
+    if not path:
+        raise HTTPException(400, "Path is required")
+    target = _safe_join(WORKSPACE_ROOT, path)
     if not os.path.exists(target) or not os.path.isfile(target):
         raise HTTPException(404, "File not found")
-    with open(target, "r", encoding="utf-8", errors="ignore") as f:
-        return {"path": path, "content": f.read()}
+    with open(target, "r", encoding="utf-8", errors="ignore") as fh:
+        content = fh.read()
+    return {"path": path, "content": content}
 
-@app.post("/api/fs/write")
-async def fs_write(payload: Dict[str, Any]):
+
+@app.post("/fs/write")
+async def fs_write(payload: Dict[str, Any]) -> Dict[str, Any]:
     path = payload.get("path")
-    content = payload.get("content","")
+    content = payload.get("content", "")
     if not path:
-        raise HTTPException(400, "Missing path")
-    target = safe_join(WORKSPACE_ROOT, path)
+        raise HTTPException(400, "Path is required")
+    target = _safe_join(WORKSPACE_ROOT, path)
     os.makedirs(os.path.dirname(target), exist_ok=True)
-    with open(target, "w", encoding="utf-8") as f:
-        f.write(content)
+    with open(target, "w", encoding="utf-8") as fh:
+        fh.write(content)
     return {"ok": True}
 
-@app.post("/api/fs/new")
-async def fs_new(payload: Dict[str, Any]):
+
+@app.post("/fs/new")
+async def fs_new(payload: Dict[str, Any]) -> Dict[str, Any]:
     path = payload.get("path")
     is_dir = bool(payload.get("is_dir", False))
     if not path:
-        raise HTTPException(400, "Missing path")
-    target = safe_join(WORKSPACE_ROOT, path)
+        raise HTTPException(400, "Path is required")
+    target = _safe_join(WORKSPACE_ROOT, path)
     if is_dir:
         os.makedirs(target, exist_ok=True)
     else:
         os.makedirs(os.path.dirname(target), exist_ok=True)
-        with open(target, "w", encoding="utf-8") as f:
-            f.write("")
+        with open(target, "w", encoding="utf-8") as fh:
+            fh.write("")
     return {"ok": True}
 
-@app.post("/api/fs/rename")
-async def fs_rename(payload: Dict[str, Any]):
+
+@app.post("/fs/rename")
+async def fs_rename(payload: Dict[str, Any]) -> Dict[str, Any]:
     src = payload.get("src")
     dst = payload.get("dst")
     if not src or not dst:
-        raise HTTPException(400, "Missing src/dst")
-    s = safe_join(WORKSPACE_ROOT, src)
-    d = safe_join(WORKSPACE_ROOT, dst)
-    os.makedirs(os.path.dirname(d), exist_ok=True)
-    os.replace(s, d)
+        raise HTTPException(400, "src and dst are required")
+    source = _safe_join(WORKSPACE_ROOT, src)
+    dest = _safe_join(WORKSPACE_ROOT, dst)
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    os.replace(source, dest)
     return {"ok": True}
 
-@app.post("/api/fs/delete")
-async def fs_delete(payload: Dict[str, Any]):
+
+@app.post("/fs/delete")
+async def fs_delete(payload: Dict[str, Any]) -> Dict[str, Any]:
     path = payload.get("path")
     if not path:
-        raise HTTPException(400, "Missing path")
-    target = safe_join(WORKSPACE_ROOT, path)
+        raise HTTPException(400, "Path is required")
+    target = _safe_join(WORKSPACE_ROOT, path)
     if os.path.isdir(target):
-        # remove dir recursively
         for root, dirs, files in os.walk(target, topdown=False):
-            for name in files:
-                os.remove(os.path.join(root, name))
-            for name in dirs:
-                os.rmdir(os.path.join(root, name))
+            for filename in files:
+                os.remove(os.path.join(root, filename))
+            for dirname in dirs:
+                os.rmdir(os.path.join(root, dirname))
         os.rmdir(target)
-    elif os.path.isfile(target):
+    elif os.path.exists(target):
         os.remove(target)
     return {"ok": True}
 
-@app.post("/api/fs/search")
-async def fs_search(payload: Dict[str, Any]):
-    query = payload.get("query","").lower()
-    scope = payload.get("path","")
-    in_files_only = bool(payload.get("in_files_only", False))
-    res = []
-    base = safe_join(WORKSPACE_ROOT, scope)
-    if not os.path.exists(base):
+
+@app.post("/fs/search")
+async def fs_search(payload: Dict[str, Any]) -> Dict[str, Any]:
+    query = (payload.get("query") or "").lower()
+    scope = payload.get("path", "")
+    if not query:
         return {"matches": []}
-    for root_dir, dirs, files in os.walk(base):
-        for fn in files:
-            fpath = os.path.join(root_dir, fn)
-            rel = os.path.relpath(fpath, WORKSPACE_ROOT).replace("\\","/")
-            if not in_files_only and query in fn.lower():
-                res.append({"path": rel, "line": 0, "context": fn})
+
+    base_dir = _safe_join(WORKSPACE_ROOT, scope)
+    if not os.path.exists(base_dir):
+        return {"matches": []}
+
+    matches: List[Dict[str, Any]] = []
+    for root_dir, _, files in os.walk(base_dir):
+        for filename in files:
+            file_path = os.path.join(root_dir, filename)
+            relative = os.path.relpath(file_path, WORKSPACE_ROOT).replace("\\", "/")
+            if query in filename.lower():
+                matches.append({"path": relative, "line": 0, "context": filename})
             try:
-                with open(fpath, "r", encoding="utf-8", errors="ignore") as fh:
-                    for i, line in enumerate(fh, 1):
+                with open(file_path, "r", encoding="utf-8", errors="ignore") as fh:
+                    for line_number, line in enumerate(fh, start=1):
                         if query in line.lower():
-                            res.append({"path": rel, "line": i, "context": line.strip()})
+                            matches.append(
+                                {
+                                    "path": relative,
+                                    "line": line_number,
+                                    "context": line.strip(),
+                                }
+                            )
             except Exception:
                 continue
-    return {"matches": res}
+    return {"matches": matches}

--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -1,334 +1,584 @@
-const $ = (q) => document.querySelector(q);
-const api = (path, opts={}) => fetch(path, opts);
+const $ = (sel) => document.querySelector(sel);
 
-let state = {
-  currentPath: null,
-  fsCache: {},
+const state = {
   settings: null,
+  currentPath: "",
+  chatHistory: [{ role: "system", content: "You are a helpful local coding assistant." }],
   streaming: false,
+  streamCancel: null,
 };
 
-async function init(){
-  const s = await (await api('/api/settings')).json();
-  state.settings = s;
+const numbers = {
+  sanitize(value, fallback) {
+    return Number.isFinite(value) ? value : fallback;
+  },
+};
+
+async function api(path, opts = {}) {
+  const res = await fetch(path, opts);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  const contentType = res.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    return res.json();
+  }
+  return res.text();
+}
+
+async function init() {
+  bindUI();
+  await loadSettings();
+  applySettingsToUI();
+  await refreshModels();
+  await refreshTree("");
+  openFile("welcome.txt", `# Welcome to Local Cursor\n\n- Configure your backend in Settings.\n- Manage files from the workspace panel.\n- Ask questions on the right to interact with the selected model.\n- Use the find/replace toolbar under the editor title.\n\nEnjoy fully offline coding assistance!\n`);
+  restoreTheme();
+}
+
+function bindUI() {
+  $('#btnSettings').addEventListener('click', showSettingsPanel);
+  $('#btnCloseSettings').addEventListener('click', hideSettingsPanel);
+  $('#settingsPanel').addEventListener('click', (ev) => {
+    if (ev.target === $('#settingsPanel')) hideSettingsPanel();
+  });
+  $('#btnSaveSettings').addEventListener('click', async () => {
+    try {
+      await saveSettings();
+      setSettingsStatus('Settings saved.', false);
+      hideSettingsPanel();
+    } catch (err) {
+      setSettingsStatus(`Failed to save: ${err.message}`, true);
+    }
+  });
+  $('#btnRefreshModels').addEventListener('click', async () => {
+    await refreshModels(true);
+  });
+  $('#backendSelect').addEventListener('change', async () => {
+    await refreshModels(true);
+  });
+
+  $('#btnTheme').addEventListener('click', toggleTheme);
+  $('#btnClearChat').addEventListener('click', clearChat);
+  $('#btnStop').addEventListener('click', stopStreaming);
+
+  $('#btnNewFile').addEventListener('click', async () => {
+    const name = prompt('New file path (relative to workspace/):', 'untitled.txt');
+    if (!name) return;
+    await api('/fs/new', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: name, is_dir: false }),
+    });
+    await refreshTree("");
+    await loadFile(name);
+  });
+
+  $('#btnNewFolder').addEventListener('click', async () => {
+    const name = prompt('New folder name:', 'folder');
+    if (!name) return;
+    await api('/fs/new', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: name, is_dir: true }),
+    });
+    await refreshTree("");
+  });
+
+  $('#btnDelete').addEventListener('click', async () => {
+    if (!state.currentPath) return;
+    if (!confirm(`Delete ${state.currentPath}?`)) return;
+    await api('/fs/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: state.currentPath }),
+    });
+    state.currentPath = "";
+    $('#editor').value = "";
+    $('#currentPath').textContent = 'No file selected';
+    await refreshTree("");
+  });
+
+  $('#btnRename').addEventListener('click', async () => {
+    if (!state.currentPath) return;
+    const newName = prompt('Rename to:', state.currentPath);
+    if (!newName || newName === state.currentPath) return;
+    await api('/fs/rename', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ src: state.currentPath, dst: newName }),
+    });
+    state.currentPath = newName;
+    $('#currentPath').textContent = newName;
+    await refreshTree("");
+  });
+
+  $('#btnSave').addEventListener('click', saveFile);
+  document.addEventListener('keydown', (ev) => {
+    const activeId = document.activeElement?.id;
+    if ((ev.metaKey || ev.ctrlKey) && ev.key.toLowerCase() === 's') {
+      ev.preventDefault();
+      saveFile();
+    }
+    if (ev.key === 'Enter' && activeId === 'searchBox') {
+      ev.preventDefault();
+      globalSearch();
+    }
+    if ((ev.metaKey || ev.ctrlKey) && ev.key.toLowerCase() === 'f') {
+      ev.preventDefault();
+      $('#findInput').focus();
+    }
+    if ((ev.metaKey || ev.ctrlKey) && ev.shiftKey && ev.key.toLowerCase() === 'f') {
+      ev.preventDefault();
+      $('#replaceInput').focus();
+    }
+  });
+
+  $('#btnFindNext').addEventListener('click', () => findNext(false));
+  $('#btnReplace').addEventListener('click', replaceSelection);
+  $('#btnReplaceAll').addEventListener('click', replaceAll);
+
+  $('#searchBox').addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter') {
+      ev.preventDefault();
+      globalSearch();
+    }
+  });
+
+  $('#btnAsk').addEventListener('click', askModel);
+  $('#chatBox').addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter' && (ev.metaKey || ev.ctrlKey)) {
+      ev.preventDefault();
+      askModel();
+    }
+  });
+}
+
+async function loadSettings() {
+  state.settings = await api('/settings');
+}
+
+function applySettingsToUI() {
+  const s = state.settings;
   $('#backendSelect').value = s.backend;
+  $('#ollamaUrl').value = s.ollama_base_url;
+  $('#lmstudioUrl').value = s.lmstudio_base_url;
   $('#temp').value = s.temperature;
   $('#topP').value = s.top_p;
   $('#maxToks').value = s.max_tokens;
-  await refreshModels();
-
-  bindUI();
-  await refreshTree("");
-  openFile("welcome.txt", "# Welcome!\n\nThis is **Local Cursor**.\n- Choose backend (Ollama or LM Studio)\n- Pick a model\n- Type on the right to chat\n- Save files in the center editor\n\nHappy hacking!\n");
 }
 
-async function refreshModels(){
-  const backendSelect = $('#backendSelect');
-  const res = await (await api('/api/models')).json().catch(()=>({models:[]}));
-  const modelSel = $('#modelSelect');
-  modelSel.innerHTML = "";
-  for(const m of (res.models||[])){
-    const opt = document.createElement('option');
-    opt.value = m; opt.textContent = m;
-    modelSel.appendChild(opt);
-  }
-  // preserve selection or fallback to settings.model
-  let want = state.settings.model;
-  if (![...modelSel.options].some(o=>o.value===want) && modelSel.options.length>0){
-    want = modelSel.options[0].value;
-  }
-  modelSel.value = want || "";
-}
-
-function bindUI(){
-  $('#btnTheme').onclick = ()=> document.body.classList.toggle('light');
-  $('#btnSettings').onclick = saveSettings;
-  $('#backendSelect').onchange = async ()=>{
-    state.settings.backend = $('#backendSelect').value;
-    await saveSettings();
-    await refreshModels();
-  };
-  $('#modelSelect').onchange = ()=> state.settings.model = $('#modelSelect').value;
-
-  $('#btnNewFile').onclick = async ()=>{
-    const name = prompt("New file name (relative to workspace):","newfile.txt");
-    if(!name) return;
-    await api('/api/fs/new', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({path:name, is_dir:false})});
-    await refreshTree("");
-    await loadFile(name);
-  };
-  $('#btnNewFolder').onclick = async ()=>{
-    const name = prompt("New folder name:","folder");
-    if(!name) return;
-    await api('/api/fs/new', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({path:name, is_dir:true})});
-    await refreshTree("");
-  };
-  $('#btnDelete').onclick = async ()=>{
-    if(!state.currentPath) return;
-    if(!confirm(`Delete ${state.currentPath}?`)) return;
-    await api('/api/fs/delete', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({path: state.currentPath})});
-    state.currentPath = null;
-    $('#editor').value = "";
-    $('#currentPath').textContent = "untitled.txt";
-    await refreshTree("");
-  };
-
-  $('#btnRename').onclick = async ()=>{
-    if(!state.currentPath) return;
-    const newName = prompt("Rename to:", state.currentPath);
-    if(!newName || newName===state.currentPath) return;
-    await api('/api/fs/rename', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({src: state.currentPath, dst: newName})});
-    state.currentPath = newName;
-    $('#currentPath').textContent = state.currentPath;
-    await refreshTree("");
-  };
-
-  $('#btnSave').onclick = saveFile;
-  document.addEventListener('keydown', (e)=>{
-    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase()==='s'){
-      e.preventDefault();
-      saveFile();
-    }
-    if (e.key.toLowerCase()==='n' && (e.ctrlKey||e.metaKey)===false){
-      if (document.activeElement.id !== 'chatBox'){
-        e.preventDefault();
-        $('#btnNewFile').click();
-      }
-    }
-    if (e.key === 'Enter' && document.activeElement.id === 'searchBox'){
-      doSearch();
-    }
+async function saveSettings() {
+  const payload = collectSettingsFromUI();
+  const res = await api('/settings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
   });
-
-  $('#searchBox').addEventListener('keydown', (e)=>{
-    if(e.key==='Enter') doSearch();
-  });
-
-  $('#btnAsk').onclick = askModel;
-}
-
-async function saveSettings(){
-  const payload = {
-    backend: $('#backendSelect').value,
-    model: $('#modelSelect').value,
-    temperature: parseFloat($('#temp').value),
-    top_p: parseFloat($('#topP').value),
-    max_tokens: parseInt($('#maxToks').value,10)
-  };
-  const res = await (await api('/api/settings', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)})).json();
   state.settings = res.settings;
+  applySettingsToUI();
+  await refreshModels();
 }
 
-async function refreshTree(path){
-  const res = await (await api(`/api/fs/list?path=${encodeURIComponent(path)}`)).json();
+function collectSettingsFromUI() {
+  const fallback = state.settings || {};
+  const temperature = parseFloat($('#temp').value);
+  const topP = parseFloat($('#topP').value);
+  const maxTokens = parseInt($('#maxToks').value, 10);
+  return {
+    backend: $('#backendSelect').value,
+    ollama_base_url: $('#ollamaUrl').value.trim(),
+    lmstudio_base_url: $('#lmstudioUrl').value.trim(),
+    model: $('#modelSelect').value,
+    temperature: numbers.sanitize(temperature, fallback.temperature ?? 0.2),
+    top_p: numbers.sanitize(topP, fallback.top_p ?? 0.9),
+    max_tokens: numbers.sanitize(maxTokens, fallback.max_tokens ?? 2048),
+  };
+}
+
+async function refreshModels(force = false) {
+  const backend = $('#backendSelect').value;
+  const baseUrl = backend === 'ollama' ? $('#ollamaUrl').value : $('#lmstudioUrl').value;
+  try {
+    const url = new URL(window.location.origin + '/models');
+    url.searchParams.set('backend', backend);
+    if (baseUrl) url.searchParams.set('base_url', baseUrl);
+    const res = await api(url.pathname + url.search);
+    const select = $('#modelSelect');
+    select.innerHTML = '';
+    (res.models || []).forEach((model) => {
+      const opt = document.createElement('option');
+      opt.value = model;
+      opt.textContent = model;
+      select.appendChild(opt);
+    });
+    const desired = $('#modelSelect').value || state.settings?.model;
+    if (desired && [...select.options].some((o) => o.value === desired)) {
+      select.value = desired;
+    } else if (select.options.length) {
+      select.value = select.options[0].value;
+    }
+    if (select.value) {
+      state.settings.model = select.value;
+    }
+    if (res.error) {
+      setSettingsStatus(`Model refresh error: ${res.error}`, true);
+    } else if (force) {
+      setSettingsStatus('Models refreshed.', false);
+    }
+  } catch (err) {
+    setSettingsStatus(`Failed to load models: ${err.message}`, true);
+  }
+}
+
+function showSettingsPanel() {
+  $('#settingsPanel').classList.remove('hidden');
+  $('#settingsPanel').setAttribute('aria-hidden', 'false');
+}
+
+function hideSettingsPanel() {
+  $('#settingsPanel').classList.add('hidden');
+  $('#settingsPanel').setAttribute('aria-hidden', 'true');
+}
+
+function setSettingsStatus(message, isError) {
+  const el = $('#settingsStatus');
+  el.textContent = message;
+  el.style.color = isError ? 'var(--danger)' : 'var(--muted)';
+}
+
+function restoreTheme() {
+  const stored = localStorage.getItem('lc-theme');
+  if (stored === 'light') {
+    document.body.classList.add('light');
+  }
+}
+
+function toggleTheme() {
+  document.body.classList.toggle('light');
+  const mode = document.body.classList.contains('light') ? 'light' : 'dark';
+  localStorage.setItem('lc-theme', mode);
+}
+
+async function refreshTree(path) {
+  const res = await api(`/fs/list?path=${encodeURIComponent(path)}`);
   const container = $('#fileTree');
-  container.innerHTML = "";
-  // Up root button
-  if (path){
+  container.innerHTML = '';
+  if (path) {
     const up = document.createElement('div');
     up.className = 'item';
     up.textContent = '⬆ ..';
-    up.onclick = ()=> refreshTree(path.split('/').slice(0,-1).join('/'));
+    up.addEventListener('click', () => {
+      const parent = path.split('/').slice(0, -1).join('/');
+      refreshTree(parent);
+    });
     container.appendChild(up);
   }
-  for(const it of res.items){
-    const el = document.createElement('div');
-    el.className = 'item';
-    el.innerHTML = it.is_dir ? `📁 ${it.name}` : `📄 ${it.name} <span class="badge">(${it.size}b)</span>`;
-    el.onclick = ()=>{
-      if(it.is_dir){
-        refreshTree(it.path);
-      }else{
-        loadFile(it.path);
-      }
-    };
-    if (it.path === state.currentPath) el.classList.add('active');
-    container.appendChild(el);
-  }
+  (res.items || []).forEach((item) => {
+    const div = document.createElement('div');
+    div.className = 'item';
+    div.textContent = item.is_dir ? '📁 ' : '📄 ';
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = item.name;
+    div.appendChild(nameSpan);
+    if (!item.is_dir) {
+      const badge = document.createElement('span');
+      badge.className = 'badge';
+      badge.textContent = `${item.size}b`;
+      badge.style.marginLeft = 'auto';
+      div.appendChild(badge);
+    }
+    if (!item.is_dir) {
+      div.addEventListener('click', () => loadFile(item.path));
+    } else {
+      div.addEventListener('click', () => refreshTree(item.path));
+    }
+    if (item.path === state.currentPath) {
+      div.classList.add('active');
+    }
+    container.appendChild(div);
+  });
 }
 
-async function loadFile(path){
-  const res = await (await api(`/api/fs/read?path=${encodeURIComponent(path)}`)).json();
+async function loadFile(path) {
+  const res = await api(`/fs/read?path=${encodeURIComponent(path)}`);
   state.currentPath = res.path;
   $('#currentPath').textContent = res.path;
   $('#editor').value = res.content;
-  highlightLineNumbers();
+  $('#editor').focus();
 }
 
-function openFile(path, content){
+function openFile(path, content) {
   state.currentPath = path;
   $('#currentPath').textContent = path;
-  $('#editor').value = content || "";
-  highlightLineNumbers();
+  $('#editor').value = content || '';
 }
 
-async function saveFile(){
-  if(!state.currentPath){
-    const name = prompt("Save as (relative path):","untitled.txt");
-    if(!name) return;
-    state.currentPath = name;
-    $('#currentPath').textContent = name;
+async function saveFile() {
+  if (!state.currentPath) {
+    const path = prompt('Save as (relative to workspace/):', 'untitled.txt');
+    if (!path) return;
+    state.currentPath = path;
   }
-  const body = {path: state.currentPath, content: $('#editor').value};
-  await api('/api/fs/write', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+  const body = {
+    path: state.currentPath,
+    content: $('#editor').value,
+  };
+  await api('/fs/write', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  $('#currentPath').textContent = state.currentPath;
   await refreshTree("");
 }
 
-async function doSearch(){
-  const q = $('#searchBox').value.trim();
-  if(!q) return;
-  const res = await (await api('/api/fs/search', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({query:q})})).json();
-  const results = res.matches || [];
-  if(results.length===0){
-    alert("No matches.");
+async function globalSearch() {
+  const query = $('#searchBox').value.trim();
+  if (!query) return;
+  const res = await api('/fs/search', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+  });
+  const matches = res.matches || [];
+  if (!matches.length) {
+    alert('No matches found.');
     return;
   }
-  const first = results[0];
-  if(first.path){
+  const first = matches[0];
+  if (first.path) {
     await loadFile(first.path);
-    // naive highlight by selecting content around line
-    setTimeout(()=>{
-      const lines = $('#editor').value.split('\n');
-      let pos=0;
-      for(let i=0;i<lines.length && i<first.line-1;i++) pos += lines[i].length+1;
-      $('#editor').focus();
-      $('#editor').setSelectionRange(pos, pos + (first.context||"").length);
-    },50);
+    highlightLine(first.line, first.context);
   }
 }
 
-function addChatMessage(text, who='assistant'){
+function highlightLine(lineNumber, context) {
+  if (!lineNumber || lineNumber < 1) return;
+  const editor = $('#editor');
+  const lines = editor.value.split('\n');
+  let start = 0;
+  for (let i = 0; i < lines.length && i < lineNumber - 1; i++) {
+    start += lines[i].length + 1;
+  }
+  const len = context ? context.length : (lines[lineNumber - 1] || '').length;
+  editor.focus();
+  editor.setSelectionRange(start, start + len);
+}
+
+function findNext(loop = true) {
+  const editor = $('#editor');
+  const query = $('#findInput').value;
+  if (!query) return;
+  const text = editor.value;
+  let idx = text.indexOf(query, editor.selectionEnd);
+  if (idx === -1 && loop) {
+    idx = text.indexOf(query, 0);
+  }
+  if (idx !== -1) {
+    editor.focus();
+    editor.setSelectionRange(idx, idx + query.length);
+  }
+}
+
+function replaceSelection() {
+  const editor = $('#editor');
+  const query = $('#findInput').value;
+  if (!query) return;
+  const replacement = $('#replaceInput').value;
+  const selected = editor.value.substring(editor.selectionStart, editor.selectionEnd);
+  if (selected === query) {
+    const before = editor.value.substring(0, editor.selectionStart);
+    const after = editor.value.substring(editor.selectionEnd);
+    const cursor = editor.selectionStart + replacement.length;
+    editor.value = before + replacement + after;
+    editor.setSelectionRange(cursor, cursor);
+  }
+  findNext();
+}
+
+function replaceAll() {
+  const editor = $('#editor');
+  const query = $('#findInput').value;
+  if (!query) return;
+  const replacement = $('#replaceInput').value;
+  const regex = new RegExp(escapeRegExp(query), 'g');
+  editor.value = editor.value.replace(regex, replacement);
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function addChatMessage(role, content) {
   const div = document.createElement('div');
-  div.className = 'chatMsg '+(who==='user'?'user':'');
-  div.textContent = text;
+  div.className = `chatMsg ${role === 'user' ? 'user' : role === 'error' ? 'error' : ''}`;
+  div.textContent = content;
   $('#chatLog').appendChild(div);
   $('#chatLog').scrollTop = $('#chatLog').scrollHeight;
+  return div;
 }
 
-async function askModel(){
-  if(state.streaming) return;
-  const q = $('#chatBox').value.trim();
-  if(!q) return;
-  $('#chatBox').value = "";
-  addChatMessage(q, 'user');
+function clearChat() {
+  state.chatHistory = [{ role: 'system', content: 'You are a helpful local coding assistant.' }];
+  $('#chatLog').innerHTML = '';
+}
 
-  const body = {
-    messages: [
-      {role:'system', content:'You are a helpful coding assistant.'},
-      {role:'user', content:q}
-    ],
-    model: $('#modelSelect').value,
-    temperature: parseFloat($('#temp').value),
-    top_p: parseFloat($('#topP').value),
-    max_tokens: parseInt($('#maxToks').value,10)
-  };
-
-  const msg = document.createElement('div');
-  msg.className = 'chatMsg';
-  msg.textContent = "";
-  $('#chatLog').appendChild(msg);
-  $('#chatLog').scrollTop = $('#chatLog').scrollHeight;
-
-  state.streaming = true;
-  const es = new EventSourcePolyfill('/api/chat/stream', { payload: body });
-  let combined = "";
-  es.onmessage = (ev)=>{
-    // default messages (not used)
-  };
-  es.addEventListener('delta', (ev)=>{
-    combined += ev.data;
-    msg.textContent = combined;
-    $('#chatLog').scrollTop = $('#chatLog').scrollHeight;
-  });
-  es.addEventListener('error', (ev)=>{
-    msg.textContent += "\n[error streaming]";
-    state.streaming = false;
-    es.close();
-  });
-  es.addEventListener('end', (ev)=>{
-    state.streaming = false;
-    es.close();
-  });
-
-  // insert into editor if checked
-  const insert = $('#cbInsert').checked;
-  if(insert){
-    const start = $('#editor').selectionStart;
-    const end = $('#editor').selectionEnd;
-    const interval = setInterval(()=>{
-      // every 150ms place current combined
-      const before = $('#editor').value.slice(0, start);
-      const after = $('#editor').value.slice(end);
-      $('#editor').value = before + combined + after;
-    }, 150);
-    es.addEventListener('end', ()=> clearInterval(interval));
-    es.addEventListener('error', ()=> clearInterval(interval));
+function stopStreaming() {
+  if (state.streamCancel) {
+    state.streamCancel();
   }
 }
 
-// SSE with POST body polyfill
-class EventSourcePolyfill {
-  constructor(url, options={}){
-    this.url = url;
-    this.payload = options.payload || null;
-    this.es = null;
-    this.listeners = {};
-    this.init();
+async function askModel() {
+  if (state.streaming) return;
+  const prompt = $('#chatBox').value.trim();
+  if (!prompt) return;
+  $('#chatBox').value = '';
+
+  state.chatHistory.push({ role: 'user', content: prompt });
+  addChatMessage('user', prompt);
+  const assistantEntry = { role: 'assistant', content: '' };
+  state.chatHistory.push(assistantEntry);
+  const assistantBubble = addChatMessage('assistant', '');
+
+  const payload = {
+    ...collectSettingsFromUI(),
+    messages: state.chatHistory,
+  };
+
+  if (!payload.model) {
+    assistantBubble.textContent = 'Select a model in settings first.';
+    return;
   }
-  async init(){
-    // Use fetch + ReadableStream to simulate SSE client
-    const res = await fetch(this.url, {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify(this.payload)
-    });
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    const emit = (type, data)=>{
-      (this.listeners[type]||[]).forEach(fn=>fn({data}));
-    };
-    while(true){
-      const {done, value} = await reader.read();
-      if(done) break;
-      buffer += decoder.decode(value, {stream:true});
-      let idx;
-      while((idx = buffer.indexOf("\n\n")) !== -1){
-        const chunk = buffer.slice(0, idx);
-        buffer = buffer.slice(idx+2);
-        const lines = chunk.split("\n");
-        let event = "message";
-        let data = "";
-        for(const line of lines){
-          if(line.startsWith("event:")) event = line.slice(6).trim();
-          else if(line.startsWith("data:")) data += line.slice(5).trim();
+
+  try {
+    state.streaming = true;
+    const insertToEditor = $('#cbInsert').checked;
+    const editor = $('#editor');
+    const selectionStart = editor.selectionStart;
+    const selectionEnd = editor.selectionEnd;
+    let latest = '';
+
+    const stream = await streamChat(payload, {
+      delta: (token) => {
+        assistantEntry.content += token;
+        latest = assistantEntry.content;
+        assistantBubble.textContent = assistantEntry.content;
+        $('#chatLog').scrollTop = $('#chatLog').scrollHeight;
+        if (insertToEditor) {
+          const before = editor.value.slice(0, selectionStart);
+          const after = editor.value.slice(selectionEnd);
+          editor.value = before + latest + after;
         }
-        if(event === "delta"){
-          this.dispatchEvent("delta", data);
-        }else if(event === "error"){
-          this.dispatchEvent("error", data);
-        }else{
-          this.dispatchEvent("message", data);
+      },
+      error: (message) => {
+        assistantBubble.classList.add('error');
+        assistantBubble.textContent = `Error: ${message}`;
+      },
+      end: async () => {
+        state.streaming = false;
+        state.streamCancel = null;
+        if (!assistantEntry.content) {
+          const fallback = await fallbackChat(payload);
+          assistantEntry.content = fallback;
+          assistantBubble.textContent = fallback;
+        }
+      },
+    });
+    state.streamCancel = stream.cancel;
+  } catch (err) {
+    state.streaming = false;
+    state.streamCancel = null;
+    assistantBubble.classList.add('error');
+    assistantBubble.textContent = `Stream failed: ${err.message}`;
+    const fallback = await fallbackChat(payload);
+    if (fallback) {
+      assistantEntry.content = fallback;
+      assistantBubble.classList.remove('error');
+      assistantBubble.textContent = fallback;
+    }
+  }
+}
+
+async function streamChat(payload, handlers) {
+  const controller = new AbortController();
+  const response = await fetch('/chat_stream', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: controller.signal,
+  });
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let ended = false;
+  const safeEnd = () => {
+    if (ended) return;
+    ended = true;
+    handlers.end?.();
+  };
+  (async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let index;
+        while ((index = buffer.indexOf('\n\n')) !== -1) {
+          const chunk = buffer.slice(0, index);
+          buffer = buffer.slice(index + 2);
+          processSseChunk(chunk, handlers, safeEnd);
         }
       }
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        handlers.error?.(err.message);
+      }
+    } finally {
+      safeEnd();
     }
-    this.dispatchEvent("end","");
-  }
-  addEventListener(type, fn){
-    (this.listeners[type] = this.listeners[type] || []).push(fn);
-  }
-  removeEventListener(type, fn){
-    this.listeners[type] = (this.listeners[type]||[]).filter(f=>f!==fn);
-  }
-  dispatchEvent(type, data){
-    (this.listeners[type]||[]).forEach(fn=>fn({data}));
-  }
-  close(){}
+  })();
+  return {
+    cancel: () => controller.abort(),
+  };
 }
 
-// simple line number helper (visual only)
-function highlightLineNumbers(){
-  // kept minimal; textarea remains simple for offline operation
+function processSseChunk(chunk, handlers, safeEnd) {
+  const lines = chunk.split('\n');
+  let event = 'message';
+  let data = '';
+  for (const line of lines) {
+    if (line.startsWith('event:')) {
+      event = line.slice(6).trim();
+    } else if (line.startsWith('data:')) {
+      data += line.slice(5).trim();
+    }
+  }
+  if (event === 'delta') {
+    handlers.delta?.(data);
+  } else if (event === 'error') {
+    handlers.error?.(data || 'Unknown error');
+  } else if (event === 'end') {
+    safeEnd();
+  }
+}
+
+async function fallbackChat(payload) {
+  try {
+    const res = await api('/chat_once', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return res.response || '';
+  } catch (err) {
+    return `Failed to get response: ${err.message}`;
+  }
 }
 
 window.addEventListener('load', init);

--- a/frontend/assets/style.css
+++ b/frontend/assets/style.css
@@ -1,52 +1,429 @@
-*{ box-sizing:border-box; }
-:root{
-  --bg:#0b1020; --bg2:#151b33;
-  --fg:#e6ebff; --muted:#a5b0d8;
-  --accent:#6ea8ff; --accent2:#93f;
-  --border:#253058;
+* { box-sizing: border-box; }
+:root {
+  color-scheme: dark;
+  --bg: #0c1222;
+  --bg2: #151c33;
+  --bg3: #0f162b;
+  --fg: #e9edff;
+  --muted: #9aa4c8;
+  --accent: #5ea0ff;
+  --accent-strong: #77b6ff;
+  --border: #27345a;
+  --danger: #ff5f6d;
 }
-body{ margin:0; background:var(--bg); color:var(--fg); font:14px/1.5 system-ui,Segoe UI,Roboto,Arial; }
-.app{ display:flex; flex-direction:column; height:100vh; }
-.topbar{
-  display:flex; align-items:center; justify-content:space-between;
-  padding:8px 12px; border-bottom:1px solid var(--border); background:linear-gradient(0deg,var(--bg2),#0e1430);
-  position:sticky; top:0; z-index:10;
+body.light {
+  color-scheme: light;
+  --bg: #f2f4ff;
+  --bg2: #ffffff;
+  --bg3: #e9edff;
+  --fg: #1b2040;
+  --muted: #5a6180;
+  --accent: #3c6dff;
+  --accent-strong: #2050ff;
+  --border: #c5cbea;
+  --danger: #d6455d;
 }
-.topbar .left, .topbar .right{ display:flex; gap:8px; align-items:center; }
-.logo{ width:22px; height:22px; }
-.brand{ font-weight:700; letter-spacing:.3px; margin-right:6px; }
-.topbar input, .topbar select, .topbar button{ background:#0f1733; color:var(--fg); border:1px solid var(--border); border-radius:8px; padding:6px 8px; }
-.topbar button{ cursor:pointer; }
-.divider{ width:1px; height:22px; background:var(--border); margin:0 6px; }
-#searchBox{ min-width:240px; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font: 14px/1.6 "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  min-height: 100vh;
+}
+button, input, select, textarea {
+  font: inherit;
+}
+button {
+  cursor: pointer;
+}
+a {
+  color: inherit;
+}
 
-.main{ display:grid; grid-template-columns: 240px 1fr 380px; gap:0; flex:1; min-height:0; }
-.sidebar{ border-right:1px solid var(--border); overflow:auto; background:#0e1430; }
-.editorPane{ display:flex; flex-direction:column; min-width:0; }
-.editorBar{ display:flex; justify-content:space-between; align-items:center; gap:8px; padding:8px 10px; border-bottom:1px solid var(--border); background:#0e1430; }
-#editor{
-  flex:1; width:100%; resize:none; border:0; outline:none; background:var(--bg); color:var(--fg);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  padding:12px; line-height:1.45; tab-size:2; white-space:pre; overflow:auto;
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  min-height: 600px;
 }
-.chatPane{ border-left:1px solid var(--border); display:flex; flex-direction:column; min-width:0; background:#0e1430; }
-.chatLog{ flex:1; padding:8px; overflow:auto; }
-.chatMsg{ background:#0b1130; border:1px solid var(--border); border-radius:10px; padding:8px 10px; margin:8px 0; white-space:pre-wrap; }
-.chatMsg.user{ background:#0f1a3f; }
-.chatInput{ padding:8px; border-top:1px solid var(--border); display:flex; flex-direction:column; gap:8px; }
-.chatInput textarea{ width:100%; resize:vertical; min-height:68px; background:var(--bg); color:var(--fg); border:1px solid var(--border); border-radius:8px; padding:8px; }
-.chatActions{ display:flex; align-items:center; justify-content:space-between; }
-.small{ font-size:12px; color:var(--muted); }
-.tree{ padding:8px; }
-.tree .item{ padding:4px 6px; border-radius:6px; cursor:pointer; display:flex; gap:6px; align-items:center; }
-.tree .item:hover{ background:#0b1130; }
-.tree .item.active{ background:#16204a; border:1px solid var(--border); }
-.badge{ font-size:11px; color:var(--muted); }
 
-/* Responsive */
-@media (max-width: 1100px){
-  .main{ grid-template-columns: 1fr; }
-  .chatPane{ order:3; }
-  .sidebar{ order:1; }
-  .editorPane{ order:2; }
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, var(--bg2), var(--bg3));
+  gap: 12px;
+}
+.topbar-left, .topbar-right {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.logo {
+  width: 22px;
+  height: 22px;
+}
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  margin-right: 8px;
+}
+.topbar input, .topbar button {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--fg);
+  padding: 6px 10px;
+}
+.topbar input {
+  min-width: 220px;
+}
+.topbar button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #0d1326;
+  font-weight: 600;
+}
+.divider {
+  height: 28px;
+  width: 1px;
+  background: var(--border);
+}
+
+.main {
+  display: grid;
+  grid-template-columns: 260px 1fr 380px;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  background: var(--bg2);
+  min-width: 0;
+}
+.sidebar-header {
+  padding: 10px 14px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+}
+.tree {
+  flex: 1;
+  overflow: auto;
+  padding: 10px 6px 40px;
+}
+.tree .item {
+  padding: 5px 10px;
+  border-radius: 8px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+.tree .item:hover {
+  background: var(--bg3);
+}
+.tree .item.active {
+  background: var(--accent);
+  color: #0d1326;
+  font-weight: 600;
+}
+.tree .item .badge {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.editorPane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg);
+}
+.editorBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg2);
+  gap: 10px;
+}
+.editorActions {
+  display: flex;
+  gap: 8px;
+}
+.editorActions button {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--fg);
+  padding: 6px 10px;
+}
+.findReplace {
+  display: flex;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg3);
+  flex-wrap: wrap;
+}
+.findReplace input {
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  padding: 6px 8px;
+}
+.findReplace button {
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg2);
+  color: var(--fg);
+  padding: 6px 10px;
+}
+#editor {
+  flex: 1;
+  width: 100%;
+  resize: none;
+  border: 0;
+  outline: none;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: "JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 16px;
+  tab-size: 2;
+  white-space: pre;
+  overflow: auto;
+}
+
+.chatPane {
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  background: var(--bg2);
+  min-width: 0;
+}
+.chatHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.chatHeader button {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--fg);
+  padding: 4px 10px;
+}
+.chatLog {
+  flex: 1;
+  padding: 12px 14px 16px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--bg);
+}
+.chatMsg {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  white-space: pre-wrap;
+  word-break: break-word;
+  animation: fadeIn 0.2s ease;
+}
+.chatMsg.user {
+  background: rgba(94, 160, 255, 0.12);
+  border-color: rgba(94, 160, 255, 0.35);
+}
+.chatMsg.error {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(3px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.chatInput {
+  padding: 12px 14px;
+  border-top: 1px solid var(--border);
+  background: var(--bg2);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.chatInput textarea {
+  width: 100%;
+  min-height: 72px;
+  resize: vertical;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  padding: 10px 12px;
+}
+.chatActions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.chatActions button {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--accent);
+  color: #0d1326;
+  padding: 6px 14px;
+  font-weight: 600;
+}
+.chatActions label {
+  color: var(--muted);
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settingsPanel {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 10, 18, 0.6);
+  backdrop-filter: blur(5px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  z-index: 50;
+}
+.settingsPanel.hidden {
+  display: none;
+}
+.settingsDialog {
+  width: min(480px, 90vw);
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.settingsDialog header,
+.settingsDialog footer {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.settingsDialog footer {
+  border-top: 1px solid var(--border);
+  border-bottom: 0;
+}
+.settingsDialog header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+.settingsDialog header button {
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--fg);
+}
+.settingsBody {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+  padding: 18px 20px 24px;
+}
+.settingsBody label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 500;
+}
+.settingsBody input,
+.settingsBody select {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  padding: 8px 10px;
+}
+.settingsActions {
+  display: flex;
+  gap: 10px;
+}
+.settingsActions button {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--fg);
+  padding: 8px 14px;
+}
+.settingsActions .primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #0d1326;
+  font-weight: 600;
+}
+#settingsStatus {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+@media (max-width: 1280px) {
+  .main {
+    grid-template-columns: 220px 1fr 340px;
+  }
+}
+@media (max-width: 1080px) {
+  .main {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(220px, 30vh) minmax(280px, 40vh) auto;
+  }
+  .sidebar {
+    order: 1;
+    min-height: 0;
+  }
+  .editorPane {
+    order: 2;
+  }
+  .chatPane {
+    order: 3;
+    min-height: 260px;
+  }
+}
+@media (max-width: 720px) {
+  .topbar-left {
+    flex: 1 1 100%;
+  }
+  .topbar {
+    flex-wrap: wrap;
+  }
+  .findReplace {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .findReplace button {
+    width: 100%;
+  }
+  .settingsBody {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,65 +1,116 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Local Cursor — Offline</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Local Cursor</title>
   <link rel="icon" href="/assets/logo.svg">
   <link rel="stylesheet" href="/assets/style.css">
 </head>
 <body>
-  <div id="app" class="app">
+  <div class="app">
     <header class="topbar">
-      <div class="left">
-        <img src="/assets/logo.svg" class="logo" alt="logo">
+      <div class="topbar-left">
+        <img src="/assets/logo.svg" class="logo" alt="Logo">
         <span class="brand">Local Cursor</span>
-        <button id="btnNewFile" title="New File (N)">＋</button>
-        <button id="btnNewFolder" title="New Folder">📁＋</button>
-        <button id="btnDelete" title="Delete">🗑️</button>
+        <button id="btnNewFile" title="New file (Ctrl+N)">＋ File</button>
+        <button id="btnNewFolder" title="New folder">＋ Folder</button>
+        <button id="btnDelete" title="Delete selected">🗑 Delete</button>
         <div class="divider"></div>
-        <input id="searchBox" placeholder="Search files or contents… (Enter)"/>
+        <input id="searchBox" placeholder="Search (Enter)" autocomplete="off">
       </div>
-      <div class="right">
-        <select id="backendSelect">
-          <option value="ollama">Ollama</option>
-          <option value="lmstudio">LM Studio</option>
-        </select>
-        <select id="modelSelect"></select>
-        <input id="temp" type="number" step="0.1" min="0" max="2" title="Temperature">
-        <input id="topP" type="number" step="0.05" min="0" max="1" title="Top P">
-        <input id="maxToks" type="number" step="1" min="128" max="8192" title="Max Tokens">
-        <button id="btnSettings" title="Save Settings">⚙️</button>
-        <button id="btnTheme" title="Toggle Theme">🌓</button>
+      <div class="topbar-right">
+        <button id="btnClearChat" title="Clear chat">🧹</button>
+        <button id="btnTheme" title="Toggle theme">🌓</button>
+        <button id="btnSettings" class="primary" title="Settings">⚙ Settings</button>
       </div>
     </header>
 
     <main class="main">
       <aside class="sidebar" id="sidebar">
+        <div class="sidebar-header">
+          <span>workspace/</span>
+        </div>
         <div class="tree" id="fileTree"></div>
       </aside>
+
       <section class="editorPane">
         <div class="editorBar">
-          <span id="currentPath">untitled.txt</span>
+          <span id="currentPath">No file selected</span>
           <div class="editorActions">
-            <button id="btnSave" title="Ctrl/Cmd+S">💾 Save</button>
-            <button id="btnRename">✎ Rename</button>
+            <button id="btnSave" title="Save (Ctrl/Cmd+S)">💾 Save</button>
+            <button id="btnRename" title="Rename">✏ Rename</button>
           </div>
+        </div>
+        <div class="findReplace">
+          <input id="findInput" placeholder="Find" autocomplete="off">
+          <input id="replaceInput" placeholder="Replace" autocomplete="off">
+          <button id="btnFindNext">Find next</button>
+          <button id="btnReplace">Replace</button>
+          <button id="btnReplaceAll">Replace all</button>
         </div>
         <textarea id="editor" spellcheck="false"></textarea>
       </section>
+
       <section class="chatPane">
+        <div class="chatHeader">
+          <span>Chat</span>
+          <button id="btnStop" title="Stop streaming">⏹ Stop</button>
+        </div>
         <div class="chatLog" id="chatLog"></div>
         <div class="chatInput">
           <textarea id="chatBox" rows="3" placeholder="Ask the local model…"></textarea>
           <div class="chatActions">
+            <label><input type="checkbox" id="cbInsert"> Insert response into editor</label>
             <button id="btnAsk">Ask ▶</button>
-            <label class="small"><input type="checkbox" id="cbInsert"/> Insert into editor</label>
           </div>
         </div>
       </section>
     </main>
   </div>
 
-  <script src="/assets/app.js"></script>
+  <div id="settingsPanel" class="settingsPanel hidden" aria-hidden="true">
+    <div class="settingsDialog" role="dialog" aria-modal="true">
+      <header>
+        <h2>Settings</h2>
+        <button id="btnCloseSettings" aria-label="Close">✕</button>
+      </header>
+      <div class="settingsBody">
+        <label>Backend
+          <select id="backendSelect">
+            <option value="ollama">Ollama</option>
+            <option value="lmstudio">LM Studio</option>
+          </select>
+        </label>
+        <label>Ollama base URL
+          <input id="ollamaUrl" type="text" placeholder="http://127.0.0.1:11434">
+        </label>
+        <label>LM Studio base URL
+          <input id="lmstudioUrl" type="text" placeholder="http://127.0.0.1:1234">
+        </label>
+        <label>Model
+          <select id="modelSelect"></select>
+        </label>
+        <label>Temperature
+          <input id="temp" type="number" step="0.1" min="0" max="2">
+        </label>
+        <label>Top P
+          <input id="topP" type="number" step="0.05" min="0" max="1">
+        </label>
+        <label>Max tokens
+          <input id="maxToks" type="number" step="1" min="64" max="8192">
+        </label>
+      </div>
+      <footer>
+        <span id="settingsStatus" role="status"></span>
+        <div class="settingsActions">
+          <button id="btnRefreshModels">Refresh models</button>
+          <button id="btnSaveSettings" class="primary">Save</button>
+        </div>
+      </footer>
+    </div>
+  </div>
+
+  <script src="/assets/app.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement a FastAPI backend that exposes offline health, settings, chat, and workspace file APIs with streaming support for Ollama and LM Studio backends
- build a responsive HTML layout for the file tree, editor, chat area, and modal settings panel with dark/light themes
- add comprehensive frontend logic for settings persistence, workspace file management, search/replace, and streaming chat with fallback handling

## Testing
- `python -m compileall backend frontend`


------
https://chatgpt.com/codex/tasks/task_e_68cc760c5a7483219cfca3473945d126