### PR TITLE
Improve UI guidance, scrolling, and backend tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Works with **Ollama** or **LM Studio** on your machine. No cloud, no paid APIs.
 - Editor with line numbers, soft-wrap, and basic shortcuts (Ctrl/Cmd+S to save)
 - Search & replace across files or in an open file
 - History log stored locally (`backend/data/history.json`)
+- Guided quick-start help overlay and beginner-friendly prompt shortcuts
 - Model parameters: temperature, top_p, max_tokens
 - Quick backend/model switcher in the top bar + searchable model palette
 - Dark/Light theme toggle
@@ -35,6 +36,10 @@ chmod +x run.sh
 ```
 Then open http://127.0.0.1:8000
 
+### Verify the local model connection
+
+Open ⚙ Settings and click **Test connection** after choosing your backend and base URL. The app reports round-trip time and a quick preview of detected models so you can confirm everything is reachable before chatting.
+
 ## Settings
 Click the ⚙️ icon in the top bar to switch between Ollama and LM Studio, choose a model, and adjust parameters.
 You can also switch backends or models instantly from the top bar quick selector.
@@ -52,6 +57,26 @@ python backend\build_exe.py --onefile
 ```
 
 The executable is created in `backend/dist/LocalCursor.exe`. Run it to start the bundled server; it opens `http://127.0.0.1:8000` in your default browser. Use `python backend\build_exe.py --check` to verify PyInstaller is available or pass `--print-only` to inspect the build command.
+
+## Keep everything up to date
+
+1. **Update your code** – pull the latest changes or sync your git fork.
+2. **Refresh dependencies** – inside the project folder run:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .\.venv\Scripts\activate
+   python -m pip install --upgrade pip
+   pip install -r backend/requirements.txt
+   ```
+   For Windows builds, also install `pip install -r backend/requirements-build.txt`.
+3. **Run a quick health check** – `python -m compileall backend` makes sure there are no syntax errors. You can also start the dev server with `./run.sh` (or `./run.ps1` on Windows) to confirm the UI loads.
+4. **Rebuild the executable when needed** –
+   ```powershell
+   python backend\build_exe.py --clean --onefile
+   ```
+   The build script prints the output path (default: `backend/dist/LocalCursor.exe`). Use `--print-only` first if you only want to review the command.
+
+Whenever you change the frontend, just refresh the browser—asset caching is disabled so the UI immediately reflects your latest edits.
 
 ## Notes
 - For **Ollama** models list, we query `/api/tags` locally.

--- a/frontend/assets/style.css
+++ b/frontend/assets/style.css
@@ -12,6 +12,7 @@
   --danger: #ff5f6d;
   --pending: #f2b35c;
   --success: #53c89b;
+  --info: #9cb7ff;
 }
 body.light {
   color-scheme: light;
@@ -26,6 +27,7 @@ body.light {
   --danger: #d6455d;
   --pending: #d89a3a;
   --success: #2c9e6d;
+  --info: #2a5fff;
 }
 body {
   margin: 0;
@@ -191,6 +193,7 @@ a {
   border-right: 1px solid var(--border);
   background: var(--bg2);
   min-width: 0;
+  min-height: 0;
 }
 .sidebar-header {
   padding: 10px 14px;
@@ -230,6 +233,7 @@ a {
   flex-direction: column;
   min-width: 0;
   background: var(--bg);
+  min-height: 0;
 }
 .editorBar {
   display: flex;
@@ -288,6 +292,7 @@ a {
   tab-size: 2;
   white-space: pre;
   overflow: auto;
+  min-height: 0;
 }
 
 .chatPane {
@@ -296,6 +301,7 @@ a {
   border-left: 1px solid var(--border);
   background: var(--bg2);
   min-width: 0;
+  min-height: 0;
 }
 .chatHeader {
   display: flex;
@@ -368,6 +374,7 @@ a {
   position: relative;
   flex: 1;
   display: flex;
+  min-height: 0;
 }
 .chatLog {
   flex: 1;
@@ -377,6 +384,64 @@ a {
   flex-direction: column;
   gap: 12px;
   background: var(--bg);
+}
+.chatAssist {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, rgba(94, 160, 255, 0.05), transparent);
+}
+.chatAssist.isHidden {
+  display: none;
+}
+.chatAssistHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+.chatAssistTitle {
+  font-weight: 600;
+  letter-spacing: 0.4px;
+}
+.chatAssistIntro {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+.chatAssistButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.chatAssistButtons button {
+  border-radius: 999px;
+  border: 1px solid rgba(94, 160, 255, 0.35);
+  background: rgba(94, 160, 255, 0.16);
+  color: var(--info);
+  padding: 6px 12px;
+  font-size: 13px;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+.chatAssistButtons button:hover {
+  transform: translateY(-1px);
+  background: rgba(94, 160, 255, 0.24);
+}
+.chatAssistButtons button:active {
+  transform: translateY(0);
+}
+.chatAssist button#btnDismissTips {
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--fg);
+  font-size: 14px;
+  padding: 0;
+  line-height: 1;
 }
 .scrollToBottom {
   position: absolute;
@@ -529,6 +594,7 @@ a {
 .settingsActions {
   display: flex;
   gap: 10px;
+  flex-wrap: wrap;
 }
 .settingsActions button {
   border-radius: 8px;
@@ -548,6 +614,83 @@ a {
   color: var(--muted);
 }
 
+.helpPanel {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 10, 18, 0.6);
+  backdrop-filter: blur(5px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  z-index: 60;
+}
+.helpPanel.hidden {
+  display: none;
+}
+.helpDialog {
+  width: min(520px, 92vw);
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+}
+.helpDialog header,
+.helpDialog footer {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.helpDialog footer {
+  border-bottom: 0;
+  border-top: 1px solid var(--border);
+  justify-content: flex-end;
+}
+.helpDialog header h2 {
+  margin: 0;
+  font-size: 20px;
+}
+.helpDialog header button,
+.helpDialog footer button {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--fg);
+  padding: 8px 14px;
+  font-weight: 600;
+}
+.helpDialog footer button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #0d1326;
+}
+.helpBody {
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.helpSteps {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.helpSteps li {
+  line-height: 1.5;
+}
+.helpNote {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
 @media (max-width: 1280px) {
   .main {
     grid-template-columns: 220px 1fr 340px;
@@ -556,18 +699,20 @@ a {
 @media (max-width: 1080px) {
   .main {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(220px, 30vh) minmax(280px, 40vh) auto;
+    grid-template-rows: auto;
+    overflow-y: auto;
   }
   .sidebar {
     order: 1;
-    min-height: 0;
+    min-height: 260px;
   }
   .editorPane {
     order: 2;
+    min-height: 320px;
   }
   .chatPane {
     order: 3;
-    min-height: 260px;
+    min-height: 360px;
   }
 }
 @media (max-width: 720px) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,7 @@
         </div>
         <button id="btnClearChat" title="Clear chat">🧹</button>
         <button id="btnTheme" title="Toggle theme">🌓</button>
+        <button id="btnHelp" title="How everything works">❔ Help</button>
         <button id="btnSettings" class="primary" title="Settings">⚙ Settings</button>
       </div>
     </header>
@@ -80,6 +81,14 @@
           <div class="chatHeaderActions">
             <button id="btnStop" title="Stop streaming">⏹ Stop</button>
           </div>
+        </div>
+        <div class="chatAssist" id="chatAssist" role="region" aria-live="polite">
+          <div class="chatAssistHeader">
+            <span class="chatAssistTitle">Need ideas?</span>
+            <button id="btnDismissTips" type="button" aria-label="Hide suggestions">✕</button>
+          </div>
+          <p class="chatAssistIntro">Pick a shortcut prompt to get going faster:</p>
+          <div class="chatAssistButtons" id="chatAssistButtons"></div>
         </div>
         <div class="chatLogWrapper">
           <div class="chatLog" id="chatLog"></div>
@@ -131,9 +140,33 @@
       <footer>
         <span id="settingsStatus" role="status"></span>
         <div class="settingsActions">
+          <button id="btnTestConnection" type="button">Test connection</button>
           <button id="btnRefreshModels">Refresh models</button>
           <button id="btnSaveSettings" class="primary">Save</button>
         </div>
+      </footer>
+    </div>
+  </div>
+
+  <div id="helpPanel" class="helpPanel hidden" aria-hidden="true">
+    <div class="helpDialog" role="dialog" aria-modal="true">
+      <header>
+        <h2>Quick help</h2>
+        <button id="btnCloseHelp" aria-label="Close help">✕</button>
+      </header>
+      <div class="helpBody">
+        <ol class="helpSteps">
+          <li><strong>Pick your backend.</strong> Use ⚙ Settings to choose Ollama or LM Studio and pick a model.</li>
+          <li><strong>Open or create a file.</strong> Use the workspace panel on the left to open files or add new ones.</li>
+          <li><strong>Ask the assistant.</strong> Type a question in the chat box or click one of the quick prompts.</li>
+          <li><strong>Insert answers.</strong> Tick “Insert response into editor” to drop code into the file you’re editing.</li>
+          <li><strong>Need an offline build?</strong> Run the build command shown in the README to create a Windows executable.</li>
+        </ol>
+        <p class="helpNote">Tip: use Ctrl/Cmd + Enter in chat to send faster, and Ctrl/Cmd + S to save the editor.</p>
+      </div>
+      <footer>
+        <button id="btnRestoreTips" type="button">Show tips again</button>
+        <button id="btnHelpCloseFooter" class="primary" type="button">Got it</button>
       </footer>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- disable caching for static assets and add a backend connection check endpoint so updates and diagnostics are instant
- enrich the frontend with a help overlay, quick prompt suggestions, dismissible tips, and a test connection button while tightening scroll behaviour on small screens
- document the new guidance and maintenance workflow in the README for easier updates and packaging

## Testing
- python -m compileall backend frontend

------
https://chatgpt.com/codex/tasks/task_e_68cca50a8220832187cc6fe221f3fece