### PR TITLE
Fix NoCacheStaticFiles override signature

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -93,7 +93,7 @@ class NoCacheStaticFiles(StaticFiles):
         response.headers["Expires"] = "0"
         return response
 
-    def is_not_modified(self, scope, request_headers, response_headers) -> bool:  # type: ignore[override]
+    def is_not_modified(self, response_headers, request_headers) -> bool:  # type: ignore[override]
         return False
 
 


### PR DESCRIPTION
## Summary
- update NoCacheStaticFiles.is_not_modified signature to match the upstream StaticFiles implementation so static assets always revalidate without raising errors

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ccdf9e555c832188492eac6c5c8aae