### PR TITLE
Improve workspace edit approvals and code insertion

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -97,7 +97,7 @@
         <div class="chatInput">
           <textarea id="chatBox" rows="3" placeholder="Ask the local model…"></textarea>
           <div class="chatActions">
-            <label><input type="checkbox" id="cbInsert"> Insert response into editor</label>
+            <label><input type="checkbox" id="cbInsert"> Allow assistant to edit workspace</label>
             <button id="btnAsk">Ask ▶</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- ensure workspace edits are only applied when the approval checkbox is checked and auto-create a target file when none is open
- sanitize streamed assistant output so only code snippets (or code-like lines) are inserted into the editor
- update the chat checkbox label to clarify that it authorizes workspace editing

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cce3c50cf88321b024be4dea8f65af