### PR TITLE
Add terminal integration, VS Code launch, and faster model handling

### DIFF
--- a/frontend/assets/style.css
+++ b/frontend/assets/style.css
@@ -522,6 +522,113 @@ a {
   gap: 6px;
 }
 
+.terminalPanel {
+  border-top: 1px solid var(--border);
+  background: var(--bg2);
+  padding: 12px 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.terminalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.terminalHeaderActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.terminalTitle {
+  font-weight: 600;
+  letter-spacing: 0.4px;
+}
+
+#terminalStatus {
+  min-height: 16px;
+}
+
+.terminalOutput {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  height: 200px;
+  overflow: auto;
+  font-family: "JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace;
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.terminalOutputEntry {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.terminalOutputEntry.command {
+  color: var(--accent);
+}
+
+.terminalOutputEntry.stderr {
+  color: var(--danger);
+}
+
+.terminalOutputEntry.meta {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.terminalForm {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.terminalForm input {
+  flex: 1;
+  min-width: 220px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  padding: 8px 10px;
+}
+
+.terminalForm button {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--accent);
+  color: #0d1326;
+  padding: 6px 16px;
+  font-weight: 600;
+}
+
+.terminalCwdLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.terminalCwdLabel select {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--fg);
+  padding: 6px 8px;
+}
+
 .settingsPanel {
   position: fixed;
   inset: 0;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,8 @@
         <button id="btnNewFile" title="New file (Ctrl+N)">＋ File</button>
         <button id="btnNewFolder" title="New folder">＋ Folder</button>
         <button id="btnDelete" title="Delete selected">🗑 Delete</button>
+        <button id="btnOpenVSCode" title="Open workspace in VS Code">🡕 VS Code</button>
+        <button id="btnCloneRepo" title="Clone GitHub repository">⎘ Clone</button>
         <div class="divider"></div>
         <input id="searchBox" placeholder="Search (Enter)" autocomplete="off">
       </div>
@@ -100,6 +102,26 @@
             <label><input type="checkbox" id="cbInsert"> Allow assistant to edit workspace</label>
             <button id="btnAsk">Ask ▶</button>
           </div>
+        </div>
+        <div class="terminalPanel" id="terminalPanel">
+          <div class="terminalHeader">
+            <span class="terminalTitle">Terminal</span>
+            <div class="terminalHeaderActions">
+              <span id="terminalStatus" role="status" aria-live="polite"></span>
+              <button id="btnClearTerminal" type="button">Clear</button>
+            </div>
+          </div>
+          <div class="terminalOutput" id="terminalOutput" role="log" aria-live="polite"></div>
+          <form id="terminalForm" class="terminalForm">
+            <input id="terminalInput" type="text" placeholder="Run command (e.g. ls -la)" autocomplete="off">
+            <label class="terminalCwdLabel">in
+              <select id="terminalCwd">
+                <option value="">workspace/</option>
+                <option value="__current__">current file folder</option>
+              </select>
+            </label>
+            <button type="submit">Run</button>
+          </form>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- ensure Ollama requests release resources quickly and add new API endpoints for workspace terminal commands, VS Code launch, and git clone support
- extend the UI with an integrated terminal panel plus controls to open VS Code or clone repositories
- wire up client logic for terminal execution, repo cloning, and safer code insertion that keeps the original selection when no code is returned

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cce8ede0f88321ad52684ad60c8255